### PR TITLE
Proposed fix for cppx/meta static_asserts

### DIFF
--- a/tools/libcppx/include/cppx/meta
+++ b/tools/libcppx/include/cppx/meta
@@ -567,11 +567,9 @@ struct function : typed<X, function_decl_kind> {
     return traits().is_defined;
   }
   static constexpr bool is_inline() {
-    static_assert(is_defined());
-    return traits().is_inline;
+    return is_defined() && traits().is_inline;
   }
   static constexpr bool is_deleted() {
-    static_assert(is_defined());
     return traits().is_deleted;
   }
 
@@ -683,20 +681,16 @@ struct method : typed<X, member_function_decl_kind> {
     return traits().is_defined;
   }
   static constexpr bool is_inline() {
-    static_assert(is_defined());
-    return traits().is_inline;
+    return is_defined() && traits().is_inline;
   }
   static constexpr bool is_deleted() {
-    static_assert(is_defined());
     return traits().is_deleted;
   }
   static constexpr bool is_defaulted() {
-    static_assert(is_defined());
     return traits().is_defaulted;
   }
   static constexpr bool is_trivial() {
-    static_assert(is_defined());
-    return traits().is_deleted;
+    return traits().is_trivial;
   }
 };
 


### PR DESCRIPTION
For example, `is_deleted` is currently written as follows:

```
  static constexpr bool is_deleted() {
    static_assert(is_defined());
    return traits().is_deleted;
  }
```

But this prevents even asking whether an undefined function is deleted -- we should be able to test and get the answer `false`, it's not deleted.

I think all 7 `static_assert`s in cppx/meta should be either removed or in some cases incorporated into their respective function bodies' conditional tests instead.