### PR TITLE
Allow templates to be applied to metaclasses

### DIFF
--- a/include/clang/Sema/Sema.h
+++ b/include/clang/Sema/Sema.h
@@ -6052,16 +6052,16 @@ public:
       ArrayRef<TemplateParameterList *> ParamLists,
       bool IsFriend, bool &IsMemberSpecialization, bool &Invalid);
 
-  DeclResult CheckClassTemplate(Scope *S, unsigned TagSpec, TagUseKind TUK,
-                                SourceLocation KWLoc, CXXScopeSpec &SS,
-                                IdentifierInfo *Name, SourceLocation NameLoc,
-                                AttributeList *Attr,
+  DeclResult CheckClassTemplate(Scope *S, unsigned TagSpec, Expr *Generator,
+                                TagUseKind TUK, SourceLocation KWLoc,
+                                CXXScopeSpec &SS, IdentifierInfo *Name,
+                                SourceLocation NameLoc, AttributeList *Attr,
                                 TemplateParameterList *TemplateParams,
                                 AccessSpecifier AS,
                                 SourceLocation ModulePrivateLoc,
                                 SourceLocation FriendLoc,
                                 unsigned NumOuterTemplateParamLists,
-                            TemplateParameterList **OuterTemplateParamLists,
+                                TemplateParameterList **OuterTemplateParamLists,
                                 SkipBodyInfo *SkipBody = nullptr);
 
   TemplateArgumentLoc getTrivialTemplateArgumentLoc(const TemplateArgument &Arg,

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -13116,8 +13116,8 @@ Decl *Sema::ActOnTag(Scope *S, unsigned TagSpec, Expr *Generator,
           return nullptr;
 
         OwnedDecl = false;
-        DeclResult Result = CheckClassTemplate(S, TagSpec, TUK, KWLoc,
-                                               SS, Name, NameLoc, Attr,
+        DeclResult Result = CheckClassTemplate(S, TagSpec, Generator, TUK,
+                                               KWLoc, SS, Name, NameLoc, Attr,
                                                TemplateParams, AS,
                                                ModulePrivateLoc,
                                                /*FriendLoc*/SourceLocation(),
@@ -13809,7 +13809,7 @@ CreateNewDecl:
     //
     // Generate something that looks (about) like this:
     //
-    //    namespace __fake__ { class Proto {... } };
+    //    namespace __fake__ { class Proto { ... } };
     //    class Class {
     //      using prototype = __fake__::Proto;
     //      constexpr { gen($Class, $__fake__::Proto); }
@@ -14149,9 +14149,9 @@ void Sema::ActOnTagFinishDefinition(Scope *S, Decl *TagD,
       //
       //    class(M) C { ... };
       //
-      // And have conceptually transformed that into something like this. 
+      // And have conceptually transformed that into something like this.
       //
-      //    namespace __fake__ { class C {... } };
+      //    namespace __fake__ { class C { ... } };
       //
       // Now, we need to build a new version of the class containing a
       // prototype and its generator.

--- a/lib/Sema/SemaDeclCXX.cpp
+++ b/lib/Sema/SemaDeclCXX.cpp
@@ -13404,7 +13404,8 @@ Decl *Sema::ActOnTemplatedFriendTag(Scope *S, SourceLocation FriendLoc,
       if (Invalid)
         return nullptr;
 
-      return CheckClassTemplate(S, TagSpec, TUK_Friend, TagLoc, SS, Name,
+      return CheckClassTemplate(S, TagSpec, /*Generator=*/nullptr,
+                                TUK_Friend, TagLoc, SS, Name,
                                 NameLoc, Attr, TemplateParams, AS_public,
                                 /*ModulePrivateLoc=*/SourceLocation(),
                                 FriendLoc, TempParamLists.size() - 1,

--- a/lib/Sema/SemaInject.cpp
+++ b/lib/Sema/SemaInject.cpp
@@ -1197,9 +1197,17 @@ Decl *InjectionContext::InjectCXXMethodDecl(CXXMethodDecl *D) {
                                    D->isInlineSpecified(), D->isConstexpr(), 
                                    D->getLocEnd());
   }
-  AddDeclSubstitution(D, Method);
 
+  AddDeclSubstitution(D, Method);
   UpdateFunctionParms(D, Method);
+
+  // Propagate Template Attributes
+  MemberSpecializationInfo *MemberSpecInfo = D->getMemberSpecializationInfo();
+  FunctionDecl *TemplateFD =
+    static_cast<FunctionDecl *>(MemberSpecInfo->getInstantiatedFrom());
+  TemplateSpecializationKind TemplateSK =
+    MemberSpecInfo->getTemplateSpecializationKind();
+  Method->setInstantiationOfMemberFunction(TemplateFD, TemplateSK);
 
   // FIXME: Propagate attributes
 
@@ -1210,7 +1218,7 @@ Decl *InjectionContext::InjectCXXMethodDecl(CXXMethodDecl *D) {
   // FIXME: Inherit access as a semantic attribute or trace it through the
   // injection as if parsing?
   Method->setImplicit(D->isImplicit());
-  
+
   // Update the access specifier.
   if (Modifiers.modifyAccess())
     Method->setAccess(Modifiers.getAccess());

--- a/lib/Sema/SemaInject.cpp
+++ b/lib/Sema/SemaInject.cpp
@@ -1203,11 +1203,13 @@ Decl *InjectionContext::InjectCXXMethodDecl(CXXMethodDecl *D) {
 
   // Propagate Template Attributes
   MemberSpecializationInfo *MemberSpecInfo = D->getMemberSpecializationInfo();
-  FunctionDecl *TemplateFD =
-    static_cast<FunctionDecl *>(MemberSpecInfo->getInstantiatedFrom());
-  TemplateSpecializationKind TemplateSK =
-    MemberSpecInfo->getTemplateSpecializationKind();
-  Method->setInstantiationOfMemberFunction(TemplateFD, TemplateSK);
+  if (MemberSpecInfo) {
+    FunctionDecl *TemplateFD =
+      static_cast<FunctionDecl *>(MemberSpecInfo->getInstantiatedFrom());
+    TemplateSpecializationKind TemplateSK =
+      MemberSpecInfo->getTemplateSpecializationKind();
+    Method->setInstantiationOfMemberFunction(TemplateFD, TemplateSK);
+  }
 
   // FIXME: Propagate attributes
 

--- a/lib/Sema/SemaTemplate.cpp
+++ b/lib/Sema/SemaTemplate.cpp
@@ -1134,15 +1134,15 @@ static void SetNestedNameSpecifier(TagDecl *T, const CXXScopeSpec &SS) {
 }
 
 DeclResult
-Sema::CheckClassTemplate(Scope *S, unsigned TagSpec, TagUseKind TUK,
-                         SourceLocation KWLoc, CXXScopeSpec &SS,
+Sema::CheckClassTemplate(Scope *S, unsigned TagSpec, Expr *Generator,
+                         TagUseKind TUK, SourceLocation KWLoc, CXXScopeSpec &SS,
                          IdentifierInfo *Name, SourceLocation NameLoc,
                          AttributeList *Attr,
                          TemplateParameterList *TemplateParams,
                          AccessSpecifier AS, SourceLocation ModulePrivateLoc,
                          SourceLocation FriendLoc,
                          unsigned NumOuterTemplateParamLists,
-                         TemplateParameterList** OuterTemplateParamLists,
+                         TemplateParameterList **OuterTemplateParamLists,
                          SkipBodyInfo *SkipBody) {
   assert(TemplateParams && TemplateParams->size() > 0 &&
          "No template parameters");
@@ -1429,6 +1429,7 @@ Sema::CheckClassTemplate(Scope *S, unsigned TagSpec, TagUseKind TUK,
                           PrevClassTemplate && ShouldAddRedecl ?
                             PrevClassTemplate->getTemplatedDecl() : nullptr,
                           /*DelayTypeCreation=*/true);
+  NewClass->setGenerator(Generator);
   SetNestedNameSpecifier(NewClass, SS);
   if (NumOuterTemplateParamLists > 0)
     NewClass->setTemplateParameterListsInfo(
@@ -7365,8 +7366,8 @@ Sema::ActOnClassTemplateSpecialization(Scope *S, unsigned TagSpec,
       Diag(TemplateNameLoc, diag::err_partial_spec_args_match_primary_template)
         << /*class template*/0 << (TUK == TUK_Definition)
         << FixItHint::CreateRemoval(SourceRange(LAngleLoc, RAngleLoc));
-      return CheckClassTemplate(S, TagSpec, TUK, KWLoc, SS,
-                                ClassTemplate->getIdentifier(),
+      return CheckClassTemplate(S, TagSpec, /*Generator=*/nullptr,
+                                TUK, KWLoc, SS, ClassTemplate->getIdentifier(),
                                 TemplateNameLoc,
                                 Attr,
                                 TemplateParams,

--- a/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -3926,7 +3926,7 @@ void Sema::InstantiateFunctionDefinition(SourceLocation PointOfInstantiation,
   // explicit specialization.
   TemplateSpecializationKind TSK = Function->getTemplateSpecializationKind();
   if (TSK == TSK_ExplicitSpecialization &&
-      !Function->getClassScopeSpecializationPattern()) 
+      !Function->getClassScopeSpecializationPattern())
     return;
 
   const FunctionDecl *PatternDecl = Function->getTemplateInstantiationPattern();


### PR DESCRIPTION
Tested against:

```
#include <cppx/meta>
#include <iostream>

template<typename T>
constexpr void interface(T source) {
  for... (auto m : source.member_variables()) {
     __generate m;
  }

  for... (auto f : source.functions()) {
     f.make_public();
     __generate f;
  }
};

template<typename T>
class(interface) Shape {
  T val;

  void set_foo(const T& val) {
    this->val = val;
  }

  T foo() {
    return val;
  }
};

int main() {
  Shape<int> shape;
  shape.set_foo(1);
  assert(shape.foo() == 1);
  std::cout << shape.foo() << '\n';
}
```